### PR TITLE
Feature reframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ puzzle
   .newPiece({up: Tab})
   .locateAt(6, 3);
 
-// Connect puzzle's near pieces
+// Connect puzzle's nearby pieces
 puzzle.autoconnect();
 
 // Translate puzzle
@@ -116,6 +116,10 @@ puzzle.translate(10, 10);
 
 // Shuffle pieces
 puzzle.shuffle(100, 100);
+
+// Relocate pieces to fit into a bounding box
+// while preserving their relative positions, if possible
+puzzle.reframe(vector(0, 0), vector(20, 20));
 
 // Directly manipulate pieces
 const [a, b, c, d] = puzzle.pieces;

--- a/docs/index.md
+++ b/docs/index.md
@@ -268,7 +268,8 @@ malharro.onload = () => {
   const offstage = new headbreaker.Canvas('offstage-canvas', {
     width: 400, height: 400, image: malharro,
     // ... more configs ...
-    preventOffstageDrag: true
+    preventOffstageDrag: true,
+    fixed: true
   });
 
   offstage.adjustImagesToPuzzleHeight();
@@ -284,6 +285,10 @@ malharro.onload = () => {
 ### Demo
 
 <div id="offstage-canvas">
+</div>
+<div class="form-group">
+  <button id="offstage-solve" class="btn btn-primary">Solve</button>
+  <button id="offstage-reframe" class="btn btn-primary">Reframe</button>
 </div>
 
 ## Randomized positions

--- a/docs/js/demo.js
+++ b/docs/js/demo.js
@@ -2,24 +2,36 @@
 // Utils
 // =====
 
+function onClick(id, handler) {
+  const element = document.getElementById(id);
+  if (element) {
+    element.addEventListener('click', function () { handler() });
+  }
+}
+
 function registerButtons(id, canvas) {
-  document.getElementById(`${id}-shuffle`).addEventListener('click', function() {
+  onClick(`${id}-shuffle`, () => {
     canvas.shuffle(0.8);
     canvas.redraw();
   });
 
-  document.getElementById(`${id}-shuffle-grid`).addEventListener('click', function() {
+  onClick(`${id}-shuffle-grid`, () => {
     canvas.shuffleGrid(1.2);
     canvas.redraw();
   });
 
-  document.getElementById(`${id}-shuffle-columns`).addEventListener('click', function() {
+  onClick(`${id}-shuffle-columns`, () => {
     canvas.shuffleColumns(1.2);
     canvas.redraw();
   });
 
-  document.getElementById(`${id}-solve`).addEventListener('click', function() {
+  onClick(`${id}-solve`, () => {
     canvas.solve();
+    canvas.redraw();
+  });
+
+  onClick(`${id}-reframe`, () => {
+    canvas.reframeWithinDimmensions();
     canvas.redraw();
   });
 }
@@ -374,11 +386,12 @@ let malharro = new Image();
 malharro.src = 'static/malharro.jpg';
 malharro.onload = () => {
   const offstage = new headbreaker.Canvas('offstage-canvas', {
-    width: 550, height: 550,
+    width: 500, height: 500,
     pieceSize: 100, proximity: 20,
     strokeWidth: 5, strokeColor: '#302B00', image: malharro,
     outline: new headbreaker.outline.Rounded(),
-    preventOffstageDrag: true
+    preventOffstageDrag: true,
+    fixed: true
   });
 
   offstage.adjustImagesToPuzzleHeight();
@@ -388,6 +401,7 @@ malharro.onload = () => {
   });
   offstage.shuffleGrid();
   offstage.draw();
+  registerButtons('offstage', offstage);
 }
 
 // =================

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -446,6 +446,11 @@ class Canvas {
     });
   }
 
+  reframeToDimmensions() {
+    this.puzzle.reframe([0, this.width], [0, this.height]);
+    this.redraw();
+  }
+
   /**
    * @param {import('./validator').ValidationListener} f
    */

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -151,6 +151,8 @@ class Canvas {
     this.figures = {};
     /** @type {Object<string, Template>} */
     this.templates = {};
+    /** @type {import('./vector').Vector} */
+    this._figurePadding = null;
   }
 
   /**
@@ -446,9 +448,20 @@ class Canvas {
     });
   }
 
-  reframeToDimmensions() {
-    this.puzzle.reframe([0, this.width], [0, this.height]);
-    this.redraw();
+  /**
+   * Translates all the pieces - preserving their relative positions - so that
+   * they all can be visible, if possible. If they are already fully visible,
+   * this method does nothing.
+   *
+   * In order to prevent unexpected translations, this method will fail
+   * if canvas is not `fixed`.
+   */
+  reframeWithinDimmensions() {
+    if (!this.fixed) throw new Error("Only fixed canvas can be reframed")
+
+    this.puzzle.reframe(
+      this.figurePadding,
+      Vector.minus(vector(this.width, this.height), this.figurePadding));
   }
 
   /**
@@ -694,6 +707,16 @@ class Canvas {
    */
   get pieceDiameter() {
     return this.pieceSize.diameter;
+  }
+
+  /**
+   * @type {import('./vector').Vector}
+   */
+  get figurePadding() {
+    if (!this._figurePadding) {
+      this._figurePadding = Vector.plus(this.strokeWidth, this.borderFill);
+    }
+    return this._figurePadding;
   }
 
   /**

--- a/src/puzzle.js
+++ b/src/puzzle.js
@@ -138,6 +138,44 @@ class Puzzle {
   translate(dx, dy) {
     this.pieces.forEach(it => it.translate(dx, dy));
   }
+
+  /**
+   * Translates all the puzzle pieces so that are completely
+   * within the given bounds.
+   *
+   * @param {import('./pair').Pair} xBounds
+   * @param {import('./pair').Pair} yBounds
+   */
+  reframe(xBounds, yBounds) {
+    let dx;
+    const leftOffstage = xBounds[0] - Math.min(...this.pieces.map(it => it.leftAnchor.x));
+    if (leftOffstage > 0) {
+      dx = leftOffstage;
+    } else {
+      const rightOffstage = xBounds[1] - Math.max(...this.pieces.map(it => it.rightAnchor.x))
+      if (rightOffstage < 0) {
+        dx = rightOffstage;
+      } else {
+        dx = 0;
+      }
+    }
+
+    let dy;
+    const upOffstage = yBounds[0] - Math.min(...this.pieces.map(it => it.upAnchor.y));
+    if (upOffstage > 0) {
+      dy = upOffstage;
+    } else {
+      const downOffstage = yBounds[1] - Math.max(...this.pieces.map(it => it.downAnchor.y))
+      if (downOffstage < 0) {
+        dy = downOffstage;
+      } else {
+        dy = 0;
+      }
+    }
+
+    this.translate(dx, dy);
+  }
+
   /**
    * @param {import('./piece').TranslationListener} f
    */

--- a/src/puzzle.js
+++ b/src/puzzle.js
@@ -141,7 +141,10 @@ class Puzzle {
 
   /**
    * Translates all the puzzle pieces so that are completely
-   * within the given bounds.
+   * within the given bounds, if possible.
+   *
+   * If pieces can not be completly places within the given
+   * bounding box, the the `max` param is ignored.
    *
    * @param {import('./vector').Vector} min
    * @param {import('./vector').Vector} max

--- a/src/puzzle.js
+++ b/src/puzzle.js
@@ -143,16 +143,16 @@ class Puzzle {
    * Translates all the puzzle pieces so that are completely
    * within the given bounds.
    *
-   * @param {import('./pair').Pair} xBounds
-   * @param {import('./pair').Pair} yBounds
+   * @param {import('./vector').Vector} min
+   * @param {import('./vector').Vector} max
    */
-  reframe(xBounds, yBounds) {
+  reframe(min, max) {
     let dx;
-    const leftOffstage = xBounds[0] - Math.min(...this.pieces.map(it => it.leftAnchor.x));
+    const leftOffstage = min.x - Math.min(...this.pieces.map(it => it.leftAnchor.x));
     if (leftOffstage > 0) {
       dx = leftOffstage;
     } else {
-      const rightOffstage = xBounds[1] - Math.max(...this.pieces.map(it => it.rightAnchor.x))
+      const rightOffstage = max.x - Math.max(...this.pieces.map(it => it.rightAnchor.x))
       if (rightOffstage < 0) {
         dx = rightOffstage;
       } else {
@@ -161,11 +161,11 @@ class Puzzle {
     }
 
     let dy;
-    const upOffstage = yBounds[0] - Math.min(...this.pieces.map(it => it.upAnchor.y));
+    const upOffstage = min.y - Math.min(...this.pieces.map(it => it.upAnchor.y));
     if (upOffstage > 0) {
       dy = upOffstage;
     } else {
-      const downOffstage = yBounds[1] - Math.max(...this.pieces.map(it => it.downAnchor.y))
+      const downOffstage = max.y - Math.max(...this.pieces.map(it => it.downAnchor.y))
       if (downOffstage < 0) {
         dy = downOffstage;
       } else {

--- a/test/puzzle-spec.js
+++ b/test/puzzle-spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const {Puzzle, Tab, Slot, PuzzleValidator, Shuffler} = require('../src/index');
+const {vector, ...Vector} = require('../src/vector');
 
 describe("puzzle", () => {
   /** @type {Puzzle} */
@@ -98,6 +99,71 @@ describe("puzzle", () => {
     assert.equal(b.rightConnection, null);
     assert.equal(c.downConnection, null);
   })
+
+  describe("reframing", () => {
+    it("reframes single offstage piece", () => {
+      puzzle = new Puzzle();
+      const piece = puzzle.newPiece({right: Tab, up: Tab});
+      piece.locateAt(-10, -10);
+
+      puzzle.reframe(Vector.zero(), vector(10, 10));
+
+      assert.deepEqual(piece.centralAnchor.asPair(), [2, 2]);
+    })
+
+    it("reframes single offstage piece - to the right", () => {
+      puzzle = new Puzzle();
+      const piece = puzzle.newPiece({right: Tab, up: Tab});
+      piece.locateAt(10, 15);
+
+      puzzle.reframe(Vector.zero(), vector(8, 12));
+
+      assert.deepEqual(piece.centralAnchor.asPair(), [6, 10]);
+    })
+
+    it("reframes multiple offstage pieces, preserving distances", () => {
+      puzzle = new Puzzle();
+      const one = puzzle.newPiece({right: Tab, up: Tab});
+      one.locateAt(-10, -10);
+
+      const other = puzzle.newPiece({right: Tab, up: Tab});
+      other.locateAt(-8, -6);
+
+      puzzle.reframe(Vector.zero(), vector(10, 10));
+
+      assert.deepEqual(one.centralAnchor.asPair(), [2, 2]);
+      assert.deepEqual(other.centralAnchor.asPair(), [4, 6]);
+    })
+
+    it("honors min bound when full refraiming is impossible", () => {
+      puzzle = new Puzzle();
+      const one = puzzle.newPiece({right: Tab, up: Tab});
+      one.locateAt(0, 0);
+
+      const other = puzzle.newPiece({right: Tab, up: Tab});
+      other.locateAt(12, 12);
+
+      puzzle.reframe(Vector.zero(), vector(10, 10));
+
+      assert.deepEqual(one.centralAnchor.asPair(), [2, 2]);
+      assert.deepEqual(other.centralAnchor.asPair(), [14, 14]);
+    })
+
+    it("reframes does nothing when pieces are already within bounds", () => {
+      puzzle = new Puzzle();
+      const one = puzzle.newPiece({right: Tab, up: Tab});
+      one.locateAt(3, 3);
+
+      const other = puzzle.newPiece({right: Tab, up: Tab});
+      other.locateAt(5, 9);
+
+      puzzle.reframe(Vector.zero(), vector(20, 20));
+
+      assert.deepEqual(one.centralAnchor.asPair(), [3, 3]);
+      assert.deepEqual(other.centralAnchor.asPair(), [5, 9]);
+    })
+
+  });
 
   describe("validation", () => {
     it("is invalid by default", () => {


### PR DESCRIPTION
# :dart: Goal

To allow `puzzle`s and `canva`s to be reframed  - that is, translate all their pieces so that they are completely within two bounding points. 

# :memo: Details

This PR introduces `Puzzle.reframe` and `Canvas.reframeWithinDimmensions`. 

# :eyes: See also

This is an answer to https://github.com/flbulgarelli/headbreaker/issues/25 request, and its code is mostly derived from that proposed there.  