### PR TITLE
Place figures on top during movement

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -720,6 +720,13 @@ class Canvas {
   }
 
   /**
+   * @type {Number}
+   **/
+  get figuresCount() {
+    return Object.values(this.figures).length;
+  }
+
+  /**
    * The puzzle rendered by this canvas
    *
    * @type {Puzzle}

--- a/src/konva-painter.js
+++ b/src/konva-painter.js
@@ -184,12 +184,12 @@ class KonvaPainter extends Painter {
   }
 
   /**
-   * @param {Canvas} _canvas
+   * @param {Canvas} canvas
    * @param {Piece} piece
    * @param {Group} group
    * @param {import('./painter').VectorAction} f
    */
-  onDrag(_canvas, piece, group, f) {
+  onDrag(canvas, piece, group, f) {
     group.on('mouseover', () => {
       document.body.style.cursor = 'pointer';
     });
@@ -198,6 +198,7 @@ class KonvaPainter extends Painter {
     });
     group.on('dragmove', () => {
       let [dx, dy] = currentPositionDiff(piece, group);
+      group.zIndex(canvas.figuresCount - 1);
       f(dx, dy);
     });
   }


### PR DESCRIPTION
# :dart: Goal

To put figures on top - and thus make them full visible - while they are grabbed. 


# :memo: Details

This improvement emerged from discussion https://github.com/flbulgarelli/headbreaker/discussions/42. 

 